### PR TITLE
Fix plugin to use updated user endpoint authentication

### DIFF
--- a/src/main/java/org/jetbrains/teamcity/githubauth/GitHubOAuthClient.java
+++ b/src/main/java/org/jetbrains/teamcity/githubauth/GitHubOAuthClient.java
@@ -3,6 +3,7 @@ package org.jetbrains.teamcity.githubauth;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -49,8 +50,14 @@ public class GitHubOAuthClient {
 
     @NotNull
     public GitHubUser getUser(@NotNull String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "token " + token);
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
         try {
-            return restTemplate.getForObject("https://api.github.com/user?access_token=" + token, GitHubUser.class);
+            return restTemplate.exchange("https://api.github.com/user", HttpMethod.GET, request, GitHubUser.class).getBody();
         } catch (RestClientException e) {
             throw new GitHubLoginException("Error obtaining GitHub user", e);
         }

--- a/src/test/java/org/jetbrains/teamcity/githubauth/GitHubOAuthTest.java
+++ b/src/test/java/org/jetbrains/teamcity/githubauth/GitHubOAuthTest.java
@@ -101,7 +101,7 @@ public class GitHubOAuthTest {
                 .andExpect(content().formData(expectedTokenBody))
                 .andRespond(withSuccess(createTokenJson(token, tokenScope), APPLICATION_JSON));
 
-        server.expect(requestTo("https://api.github.com/user?access_token=" + token)).andExpect(method(GET))
+        server.expect(requestTo("https://api.github.com/user")).andExpect(method(GET))
                 .andRespond(withSuccess(userJson, APPLICATION_JSON));
     }
 


### PR DESCRIPTION
This plugin is currently broken, giving `Error obtaining GitHub User` when a user tries to log in through GitHub OAuth. This is because the `/user` endpoint is passed the authentication token as a query parameter, which has been deprecated. 

This PR adds the authentication token as a header, which is now how GitHub recommends it is supplied.